### PR TITLE
Send extra events to ingestor

### DIFF
--- a/logdna.py
+++ b/logdna.py
@@ -3,6 +3,7 @@
      LogDNA Engine -- sends information on salt events to LogDNA
 '''
 from __future__ import absolute_import
+from fnmatch import fnmatch
 from threading import Timer
 
 import sys
@@ -16,55 +17,66 @@ log = logging.getLogger(__name__)
 _max_bytes = 10000
 
 class event_batcher(object):
-    def __init__(self, ingestion_key, max_bytes=_max_bytes):
+
+    def __init__(self, ingestion_key, extra_events=[], max_bytes=_max_bytes):
+
         self.events = []
         self.key = ingestion_key
+        self.extra_events = extra_events
         self.timer = None
         self.currentByteLength = 0
         self.maxByteLength = max_bytes
         self.headers = {'content-type': 'application/json'}
         self.logdna_endpoint = 'https://logs.logdna.com/webhooks/salt'
 
-
     def flush(self):
+
         if self.timer:
             self.timer.cancel()
             self.timer = None
+
         r = requests.post(self.logdna_endpoint, data=json.dumps(self.events), auth=('logdna', self.key), headers=self.headers)
         self.events = []
         self.currentByteLength = 0
 
-    def sendEvent(self, payload, timestamp=""):
+    def sendEvent(self, event, timestamp=''):
         if not timestamp:
             timestamp = int(time.time())
 
-        payload = json.loads(payload)
-
-        if 'fun' not in payload:
-            return
+        tag, payload = event
 
         if payload['fun'] == 'state.highstate' or payload['fun'] == 'state.apply' or payload['fun'] == 'state.sls':
-            data = {"time": timestamp}
-            data.update([("func", payload['fun'])])
-            data.update([("payload", payload)])
+            data = {'time': timestamp}
+            data.update({'func': payload['fun']})
+            data.update({'payload': payload})
             self.events.append(data)
 
             self.currentByteLength += sys.getsizeof(data)
+        else:
+            for event_str in self.extra_events:
+                if fnmatch(tag, event_str):
+                    data = {'time': timestamp}
+                    data.update({'event': tag})
+                    data.update({'payload': payload})
+                    self.events.append(data)
 
-            if self.timer == None:
-                self.timer = Timer(10, self.flush)
-                self.timer.start()
+                    self.currentByteLength += sys.getsizeof(data)
+                else:
+                    continue
 
-            if self.currentByteLength > self.maxByteLength:
-                self.flush()
+        if self.timer == None:
+            self.timer = Timer(10, self.flush)
+            self.timer.start()
+
+        if self.currentByteLength > self.maxByteLength:
+            self.flush()
 
 
-
-def start(ingestion_key=None):
+def start(ingestion_key=None, extra_events=[]):
     if ingestion_key == None:
         log.warning('Please specify your LogDNA Ingestion Key in your LogDNA engine config.')
 
-    logdna_batcher = event_batcher(ingestion_key)
+    logdna_batcher = event_batcher(ingestion_key, extra_events=extra_events)
 
     if __opts__['__role'] == 'master':
         event_bus = salt.utils.event.get_master_event(
@@ -82,6 +94,5 @@ def start(ingestion_key=None):
 
     while True:
         event = event_bus.get_event()
-        jevent = json.dumps(event)
         if event:
-            logdna_batcher.sendEvent(jevent)
+            logdna_batcher.sendEvent(event)


### PR DESCRIPTION
I thought it would be useful if we were able to specify additional events that could be captured off the salt event bus and put into LogDNA. It wasn't until afterwards that I realized that your webhook is geared only towards state application events. 

Hopefully this is useful at some point in the future? :)